### PR TITLE
feat: add runtime callers skip option

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -25,6 +25,7 @@ type Logger struct {
 	ReportCaller   bool
 	LowerLevelName bool
 	MaxCallerDepth int
+	CallerSkip     int
 
 	// Reusable empty record
 	recordPool sync.Pool
@@ -466,7 +467,7 @@ func (l *Logger) write(level Level, r *Record) {
 	// log caller
 	if l.ReportCaller {
 		// l.mu.Lock()
-		r.Caller = getCaller(l.MaxCallerDepth)
+		r.Caller = getCaller(l.MaxCallerDepth, l.CallerSkip)
 		// l.mu.Unlock()
 	}
 

--- a/util.go
+++ b/util.go
@@ -45,11 +45,11 @@ func getPackageName(f string) string {
 }
 
 // getCaller retrieves the name of the first non-slog calling function
-func getCaller(maxCallerDepth int) *runtime.Frame {
+func getCaller(maxCallerDepth, callerSkip int) *runtime.Frame {
 	// cache this package's fully-qualified name
 	callerInitOnce.Do(func() {
 		pcs := make([]uintptr, maxCallerDepth)
-		_ = runtime.Callers(0, pcs)
+		_ = runtime.Callers(callerSkip, pcs)
 
 		// dynamic get the package name and the minimum caller depth
 		for i := 0; i < maxCallerDepth; i++ {
@@ -60,7 +60,7 @@ func getCaller(maxCallerDepth int) *runtime.Frame {
 			}
 		}
 
-		minCallerDepth = defaultKnownSlogFrames
+		minCallerDepth = defaultKnownSlogFrames + callerSkip
 	})
 
 	// Restrict the lookback frames to avoid runaway lookups


### PR DESCRIPTION
When I was customizing my log file based by slog, I found that the `Caller Depth` was not correct. It's always prints the number of lines of code in the log file. So I add `skip caller` option by referring to the [zap implementation](https://github.com/uber-go/zap/blob/master/stacktrace.go#L70)

Before: ⬇️
```Go
// mylog.log file
func newStdLogger(level slog.Level) *slog.SugaredLogger {
	return slog.NewSugaredLogger(os.Stdout, level).Configure(func(sl *slog.SugaredLogger) {
		sl.SetName("stdLogger")
		sl.ReportCaller = true
		sl.Formatter.(*slog.TextFormatter).EnableColor = color.SupportColor()
		sl.Formatter.(*slog.TextFormatter).SetTemplate(template)
	})
}

var std = &slog.SugaredLogger{}

// Trace logs a message at level Trace
func Debug(args ...interface{}) {
	std.Log(slog.DebugLevel, args...)
}

>>> output
[2022/04/15 19:38:27] [DEBUG] [mylog.go:94,Debug] test log 
[2022/04/15 19:38:27] [DEBUG] [mylog.go:94,Debug] test log 
[2022/04/15 19:38:27] [DEBUG] [mylog.go:94,Debug] test log 
```

Now: ⬇️
```Go
// mylog.log file
func newStdLogger(level slog.Level) *slog.SugaredLogger {
	return slog.NewSugaredLogger(os.Stdout, level).Configure(func(sl *slog.SugaredLogger) {
		sl.SetName("stdLogger")
		sl.ReportCaller = true
		sl.CallerSkip = 3
		sl.Formatter.(*slog.TextFormatter).EnableColor = color.SupportColor()
		sl.Formatter.(*slog.TextFormatter).SetTemplate(template)
	})
}

>>> output
[2022/04/15 19:38:27] [DEBUG] [decrypter.go:31,Decrypt] test log 
[2022/04/15 19:38:27] [DEBUG] [browser.go:92,New] test log 
[2022/04/15 19:38:27] [DEBUG] [main.go:55,func1] test log 
```
