### PR TITLE
Introduce new config option: WithFilePerm.

### DIFF
--- a/rotatefile/config.go
+++ b/rotatefile/config.go
@@ -146,6 +146,9 @@ type Config struct {
 	// Filepath the log file path, will be rotating
 	Filepath string `json:"filepath" yaml:"filepath"`
 
+	// FilePerm the log file permission, default is 0644.
+	FilePerm os.FileMode `json:"fileperm" yaml:"fileperm"`
+
 	// MaxSize file contents max size, unit is bytes.
 	// If is equals zero, disable rotate file by size
 	//
@@ -219,8 +222,6 @@ const (
 )
 
 var (
-	// DefaultFilePerm perm and flags for create log file
-	DefaultFilePerm os.FileMode = 0664
 	// DefaultFileFlags for open log file
 	DefaultFileFlags = os.O_CREATE | os.O_WRONLY | os.O_APPEND
 
@@ -241,6 +242,7 @@ var (
 // NewDefaultConfig instance
 func NewDefaultConfig() *Config {
 	return &Config{
+		FilePerm:   0644,
 		MaxSize:    DefaultMaxSize,
 		RotateTime: EveryHour,
 		BackupNum:  DefaultBackNum,
@@ -274,5 +276,11 @@ func EmptyConfigWith(fns ...ConfigFn) *Config {
 func WithFilepath(logfile string) ConfigFn {
 	return func(c *Config) {
 		c.Filepath = logfile
+	}
+}
+
+func WithFilePerm(perm os.FileMode) ConfigFn {
+	return func(c *Config) {
+		c.FilePerm = perm
 	}
 }

--- a/rotatefile/writer.go
+++ b/rotatefile/writer.go
@@ -223,7 +223,7 @@ func (d *Writer) ReopenFile() error {
 
 // ReopenFile the log file
 func (d *Writer) openFile() error {
-	file, err := fsutil.OpenFile(d.cfg.Filepath, DefaultFileFlags, DefaultFilePerm)
+	file, err := fsutil.OpenFile(d.cfg.Filepath, DefaultFileFlags, d.cfg.FilePerm)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- fixes #102
- Removes global var `DefaultFilePerm`. Does this breaks backward compatibility? `DefaultFilePerm` is supposed to be an internal var (`defaultFilePerm`).
- Default file permission is still `0664`, set in `NewDefaultConfig()`.
- New config option `WithFilePerm()`.