### PR TITLE
Fixes the directory for cleaning files

### DIFF
--- a/rotatefile/writer.go
+++ b/rotatefile/writer.go
@@ -317,7 +317,7 @@ func (d *Writer) Clean() (err error) {
 	fileDir, fileName := path.Split(d.cfg.Filepath)
 
 	// find and clean old files
-	err = fsutil.FindInDir(fileDir[:len(fileDir)-2], func(fPath string, ent fs.DirEntry) error {
+	err = fsutil.FindInDir(fileDir[:len(fileDir)-1], func(fPath string, ent fs.DirEntry) error {
 		fi, err := ent.Info()
 		if err != nil {
 			return err

--- a/rotatefile/writer_test.go
+++ b/rotatefile/writer_test.go
@@ -128,6 +128,9 @@ func TestWriter_Clean(t *testing.T) {
 		c.Compress = true
 		err = wr.Clean()
 		assert.NoErr(t, err)
+
+		files := fsutil.Glob(logfile + ".*")
+		assert.Equal(t, 2, len(files))
 	})
 }
 


### PR DESCRIPTION
I noticed that the logs were not cleaned at all. By looking through the code I noticed that the last letter of the directory gets stripped. I changed this to remove only the trailing slash.

I also noticed that a directory is always required within the file path e.g. "xyz.log", one has to enter "./xyz.log". Should that be documented somewhere? 